### PR TITLE
pfj13-fixing deploy command to better support local deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ go build ./src/janus-cli
 Having an ssh key par configured and already passed as authorized_keys on remote device is required. Need help with this? Click [here](https://phoenixnap.com/kb/ssh-with-key).
 
 ```
-./janus-cli deploy --agent-port 8001 --agent-name demo-agent -H user@127.0.0.2
+./janus-cli deploy remote  --agent-port 8001 --agent-name demo -H user@192.168.0.2
 ```
 
 the aries agent will be available at port 8001 and the admin page at 8002
@@ -34,18 +34,11 @@ the aries agent will be available at port 8001 and the admin page at 8002
 To deploy locally you can run, but it will only be able to communicate with other local agents.
 
 ```
-./janus-cli deploy --agent-port 8001 --agent-name demo-agent 
+./janus-cli deploy local --agent-port 8001 --agent-name demo
 ```
 
-If you want to have a communication between local and remote devices you need to:
+If you want to have a communication between local and remote devices you need to pass the network ip for local device:
 
 ```
-# check you network IP
-
-hostname -I
-> 127.0.0.1
-
-# deploy the agent asking for a ssh connection with the localhost
-
-./janus-cli deploy --agent-port 8001 --agent-name demo-agent -H user@127.0.0.1
+./janus-cli deploy local --agent-port 8001 --agent-name demo --agent-ip 192.168.0.1
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,31 +2,42 @@ version: "3.5"
 
 services:
   agent:
-    platform: linux/amd64
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
+    image: bcgovimages/aries-cloudagent:py36-1.16-1_1.0.0-rc1
 
-    container_name: acapy-agent
+    container_name: aca-py-agent-${AGENT_NAME}
     environment:
-      ACAPY_ENDPOINT: "http://${ENDPOINT}:${AGENT_PORT}"
+      ACAPY_ENDPOINT: "${ENDPOINT}:${AGENT_PORT}"
       ACAPY_LABEL: "${AGENT_NAME}"
 
       ACAPY_ADMIN_INSECURE_MODE: "true"
       ACAPY_AUTO_PROVISION: "true"
       ACAPY_LOG_LEVEL: "info"
-      
+
       ACAPY_GENESIS_URL: "http://dev.bcovrin.vonx.io/genesis"
       ACAPY_WALLET_TYPE: "indy"
       ACAPY_WALLET_SEED: "${WALLET_SEED}"
       ACAPY_WALLET_NAME: "wallet${AGENT_NAME}"
       ACAPY_WALLET_KEY: "walletkey"
+      #ACAPY_WEBHOOK_URL: "${ENDPOINT}:1080/"
 
     entrypoint: /bin/bash
-    command: ["-c",
-        "aca-py start \
-        --inbound-transport http '0.0.0.0' ${AGENT_PORT} \
-        --outbound-transport http \
-        --admin '0.0.0.0' ${ADMIN_PORT}"
-    ]
+    command:
+      [
+        "-c",
+        "aca-py start 
+        --inbound-transport http '0.0.0.0' ${AGENT_PORT} 
+        --outbound-transport http 
+        --admin '0.0.0.0' ${ADMIN_PORT}
+        --auto-accept-invites
+        --auto-accept-requests
+        --auto-ping-connection
+        --auto-respond-credential-proposal
+        --auto-respond-credential-offer
+        --auto-respond-credential-request
+        --auto-store-credential
+        --auto-respond-presentation-proposal
+        # --auto-respond-presentation-request"
+      ]
     ports:
       - "${ADMIN_PORT}:${ADMIN_PORT}"
       - "${AGENT_PORT}:${AGENT_PORT}"

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -22,8 +22,14 @@ func InstantiateAgent(agent AgentInfo, hostName string) error {
 		command += fmt.Sprintf("-H ssh://%s ", hostName)
 	}
 
+	projectName := "janus-agent"
+
+	if agent.Name != "" {
+		projectName += fmt.Sprintf("-%s", agent.Name)
+	}
+
 	// append the rest of the command
-	command += "compose -f /tmp/janus/docker-compose.yml -p janus-agent up -d"
+	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml -p %s up -d", projectName)
 
 	parsedCommand := parseCommand(command)
 

--- a/pkg/agent_deploy/ledger.go
+++ b/pkg/agent_deploy/ledger.go
@@ -3,6 +3,7 @@ package agent_deploy
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"math/rand"
 	"net/http"
 	"time"
@@ -60,4 +61,16 @@ func RegisterDID(seed, ledgerURL string) (string, error) {
 	}
 
 	return response.DID, err
+}
+
+func ProvideDid() (seed, did string) {
+	seed = GenerateSeed()
+
+	// Register DID
+	did, err := RegisterDID(seed, "http://dev.bcovrin.vonx.io")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return
 }

--- a/src/janus-cli/cmd/deploy.go
+++ b/src/janus-cli/cmd/deploy.go
@@ -1,24 +1,12 @@
 package cmd
 
 import (
-	"encoding/json"
-	"log"
-	"net"
-	"strconv"
-	"strings"
-
-	"github.com/Instituto-Atlantico/janus/pkg/agent_deploy"
-
 	"github.com/spf13/cobra"
 )
 
 var (
 	agentName string
 	agentPort int
-
-	hostName string
-
-	localIp net.IP
 )
 
 // DeployCmd represents the deploy command
@@ -26,74 +14,14 @@ var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Deploy an aca-py agent",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		if hostName != "" {
-			valid := agent_deploy.ValidateSSHHostName(hostName)
-			if !valid {
-				log.Fatal("hostname flag must be on user@ip format")
-			}
-		}
-
-		deployAgent()
-	},
+	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {
-	var err error
+	deployCmd.PersistentFlags().StringVar(&agentName, "agent-name", "", "The aca-py agent name. This flag is optional but recommended so the agent will be better named")
+	deployCmd.PersistentFlags().IntVar(&agentPort, "agent-port", 0, "The aca-py agent port. This flag is required and agent-port+1 will be used for aca-py admin page")
 
-	localIp, err = agent_deploy.GetOutboundIP()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	deployCmd.Flags().StringVarP(&hostName, "host-name", "H", "", "The hostname of the target host you want to deploy the agent. The required format is user@ip.")
-	deployCmd.Flags().StringVar(&agentName, "agent-name", "", "The aca-py agent name. This flag is optional but recommended so the agent will be better named")
-	deployCmd.Flags().IntVar(&agentPort, "agent-port", 0, "The aca-py agent port. This flag is required and agent-port+1 will be used for aca-py admin page")
-
-	deployCmd.MarkFlagRequired("agent-port")
-	deployCmd.MarkFlagRequired("host-name")
+	deployCmd.MarkPersistentFlagRequired("agent-port")
 
 	rootCmd.AddCommand(deployCmd)
-}
-
-func deployAgent() {
-	agent := agent_deploy.AgentInfo{
-		Name:      agentName,
-		AdminPort: strconv.Itoa(agentPort + 1),
-		AgentPort: strconv.Itoa(agentPort),
-	}
-
-	// Generate seed
-	agent.Seed = agent_deploy.GenerateSeed()
-	log.Printf("Seed generated: %s\n", agent.Seed)
-
-	// Register DID
-	did, err := agent_deploy.RegisterDID(agent.Seed, "http://dev.bcovrin.vonx.io")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Printf("DiD registered: %s\n", did)
-
-	// Define endpoint
-	if hostName != "" {
-		agent.Endpoint = strings.Split(hostName, "@")[1]
-	} else {
-		agent.Endpoint = localIp.String()
-	}
-
-	// log results
-	parsedAgent, err := json.Marshal(agent)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Printf("Deploying agent: %s\n", parsedAgent)
-
-	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, hostName)
-	if err != nil {
-		log.Fatal(err)
-	}
 }

--- a/src/janus-cli/cmd/local.go
+++ b/src/janus-cli/cmd/local.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/Instituto-Atlantico/janus/pkg/agent_deploy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	agentEndpoint string
+)
+
+// localCmd represents the local command
+var localCmd = &cobra.Command{
+	Use:   "local",
+	Short: "deploy an aca-py agent locally",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		deployAgentLocally()
+	},
+}
+
+func init() {
+	deployCmd.AddCommand(localCmd)
+
+	localIp, err := agent_deploy.GetOutboundIP()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	localCmd.Flags().StringVar(&agentEndpoint, "agent-ip", localIp.String(), "The ip that other agents will use to communicate with this. If blank it will be taken automatically.")
+}
+
+func deployAgentLocally() {
+	agent := agent_deploy.AgentInfo{
+		Name:      agentName,
+		AdminPort: strconv.Itoa(agentPort + 1),
+		AgentPort: strconv.Itoa(agentPort),
+		Endpoint:  fmt.Sprintf("http://%s", agentEndpoint),
+	}
+
+	// generate seed and did
+	seed, did := agent_deploy.ProvideDid()
+	log.Printf("Seed generated: %s\n", seed)
+	log.Printf("DiD registered: %s\n", did)
+
+	agent.Seed = seed
+
+	// log agent
+	parsedAgent, err := json.Marshal(agent)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Deploying agent: %s\n", parsedAgent)
+
+	// Instantiate Agent
+	err = agent_deploy.InstantiateAgent(agent, "")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/src/janus-cli/cmd/remote.go
+++ b/src/janus-cli/cmd/remote.go
@@ -1,0 +1,72 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/Instituto-Atlantico/janus/pkg/agent_deploy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	hostName string
+)
+
+// remoteCmd represents the remote command
+var remoteCmd = &cobra.Command{
+	Use:   "remote",
+	Short: "Deploy an aca-py agent remotely",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		valid := agent_deploy.ValidateSSHHostName(hostName)
+		if !valid {
+			log.Fatal("hostname flag must be on user@ip format")
+		}
+
+		deployAgentRemotely()
+	},
+}
+
+func init() {
+	remoteCmd.Flags().StringVarP(&hostName, "host-name", "H", "", "The hostname of the target host you want to deploy the agent. The required format is user@ip.")
+	remoteCmd.MarkFlagRequired("host-name")
+
+	deployCmd.AddCommand(remoteCmd)
+}
+
+func deployAgentRemotely() {
+	agent := agent_deploy.AgentInfo{
+		Name:      agentName,
+		AdminPort: strconv.Itoa(agentPort + 1),
+		AgentPort: strconv.Itoa(agentPort),
+		Endpoint:  fmt.Sprintf("http://%s", strings.Split(hostName, "@")[1]),
+	}
+
+	// generate seed and did
+	seed, did := agent_deploy.ProvideDid()
+	log.Printf("Seed generated: %s\n", seed)
+	log.Printf("DiD registered: %s\n", did)
+
+	agent.Seed = seed
+
+	// log agent
+	parsedAgent, err := json.Marshal(agent)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Deploying agent: %s\n", parsedAgent)
+
+	// Instantiate Agent
+	err = agent_deploy.InstantiateAgent(agent, hostName)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
After adding the remote deploy, the local deploy went kinda bugged. The intent of this PR is to separete both ways to deploy in independent and self contained and "conditionaless"commands

Also, the autorespond flags were added to the agents