### PR TITLE
pfj-18 add sensor collector and amd64 emulator on raspberry pi deploy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,24 +34,27 @@ services:
         --auto-respond-credential-offer
         --auto-respond-credential-request
         --auto-store-credential
-        --auto-respond-presentation-proposal
-        # --auto-respond-presentation-request"
+        --auto-respond-presentation-proposal"
       ]
     ports:
       - "${ADMIN_PORT}:${ADMIN_PORT}"
       - "${AGENT_PORT}:${AGENT_PORT}"
+    depends_on: #required while image doesnt support arm architecture
+      - amd64_emulator
     profiles:
-      - unknow
+      - raspberry
+      - server
 
-  # amd64:
-  #   image: tonistiigi/binfmt
-  #   command: install amd64
-  #   profiles:
-  #     - rasp
+  amd64_emulator:
+    image: tonistiigi/binfmt
+    privileged: true
+    command: "--install amd64"  
+    profiles:
+      - raspberry
 
   temp_collector:
     image: elazzar/rpi-dht11-api-docker
     ports: 
       - 5000:5000
     profiles:
-      - rasp
+      - raspberry

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,8 +53,9 @@ services:
       - raspberry
 
   temp_collector:
-    image: elazzar/rpi-dht11-api-docker
+    image: allthingscloud/rpi3-python-iot-api-dht
+    privileged: true
     ports: 
-      - 5000:5000
+      - 8989:8989
     profiles:
       - raspberry

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       ACAPY_WALLET_SEED: "${WALLET_SEED}"
       ACAPY_WALLET_NAME: "wallet${AGENT_NAME}"
       ACAPY_WALLET_KEY: "walletkey"
-      #ACAPY_WEBHOOK_URL: "${ENDPOINT}:1080/"
 
     entrypoint: /bin/bash
     command:
@@ -41,3 +40,18 @@ services:
     ports:
       - "${ADMIN_PORT}:${ADMIN_PORT}"
       - "${AGENT_PORT}:${AGENT_PORT}"
+    profiles:
+      - unknow
+
+  # amd64:
+  #   image: tonistiigi/binfmt
+  #   command: install amd64
+  #   profiles:
+  #     - rasp
+
+  temp_collector:
+    image: elazzar/rpi-dht11-api-docker
+    ports: 
+      - 5000:5000
+    profiles:
+      - rasp

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -14,7 +14,7 @@ type AgentInfo struct {
 	AgentPort string
 }
 
-func InstantiateAgent(agent AgentInfo, hostName string) error {
+func InstantiateAgent(agent AgentInfo, hostName, profile string) error {
 	command := "docker "
 
 	// add -H host name if remote deploying
@@ -29,7 +29,7 @@ func InstantiateAgent(agent AgentInfo, hostName string) error {
 	}
 
 	// append the rest of the command
-	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile raspberry -p %s up -d", projectName)
+	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile %s -p %s up -d", profile, projectName)
 
 	fmt.Println(command)
 	parsedCommand := parseCommand(command)

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -29,8 +29,9 @@ func InstantiateAgent(agent AgentInfo, hostName string) error {
 	}
 
 	// append the rest of the command
-	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml -p %s up -d", projectName)
+	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile raspberry -p %s up -d", projectName)
 
+	fmt.Println(command)
 	parsedCommand := parseCommand(command)
 
 	cmd := exec.Command(parsedCommand[0], parsedCommand[1:]...)

--- a/src/janus-cli/cmd/local.go
+++ b/src/janus-cli/cmd/local.go
@@ -62,7 +62,7 @@ func deployAgentLocally() {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, "")
+	err = agent_deploy.InstantiateAgent(agent, "", "server")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/janus-cli/cmd/remote.go
+++ b/src/janus-cli/cmd/remote.go
@@ -65,7 +65,7 @@ func deployAgentRemotely() {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, hostName)
+	err = agent_deploy.InstantiateAgent(agent, hostName, "raspberry")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The objective of this PR is to include two additional services to run on rasp deployment:
1) the DTH11 sensor collector to get the sensor information;
2) the amd64 emulator, required by now because multiarchitecture images are not available for aca-py 