### PR TITLE
PFJ-19 Update sensor collector image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,9 +53,9 @@ services:
       - raspberry
 
   temp_collector:
-    image: allthingscloud/rpi3-python-iot-api-dht
+    image: elazzar/rpi-dht11-api-docker
     privileged: true
     ports: 
-      - 8989:8989
+      - 5000:5000
     profiles:
       - raspberry


### PR DESCRIPTION
As a goal of this PR:

1. Update image and port for API access.

**Note:** Adjustments were made to the code to collect data from the sensors in order to be more stable. 

Repository used to collect data sensors - [rpi-dht11-api-docker](https://github.com/eltonlazzarin/rpi-dht11-api-docker)
