### PR TITLE
pfj-25-avoid redeploying agents on janus-controller

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   agent:
     image: bcgovimages/aries-cloudagent:py36-1.16-1_1.0.0-rc1
 
-    container_name: aca-py-agent-${AGENT_NAME}
+    container_name: aca-py-${AGENT_NAME}
     environment:
       ACAPY_ENDPOINT: "${ENDPOINT}:${AGENT_PORT}"
       ACAPY_LABEL: "${AGENT_NAME}"
@@ -46,6 +46,7 @@ services:
       - server
 
   amd64_emulator:
+    container_name: amd64
     image: tonistiigi/binfmt
     privileged: true
     command: "--install amd64"  
@@ -53,6 +54,7 @@ services:
       - raspberry
 
   temp_collector:
+    container_name: temp_collector
     image: elazzar/rpi-dht11-api-docker
     privileged: true
     ports: 

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -31,7 +31,7 @@ func InstantiateAgent(agent AgentInfo, hostName, profile string) error {
 	}
 
 	// append the rest of the command
-	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile %s -p %s up -d", profile, projectName)
+	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile %s -p %s up --no-recreate -d", profile, projectName)
 
 	fmt.Println(command)
 	parsedCommand := helper.ParseCommand(command)

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -24,7 +24,7 @@ func InstantiateAgent(agent AgentInfo, hostName, profile string, allowRedeploy b
 		command += fmt.Sprintf("-H ssh://%s ", hostName)
 	}
 
-	projectName := "janus-agent"
+	projectName := "janus"
 
 	if agent.Name != "" {
 		projectName += fmt.Sprintf("-%s", agent.Name)

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -16,7 +16,7 @@ type AgentInfo struct {
 	AgentPort string
 }
 
-func InstantiateAgent(agent AgentInfo, hostName, profile string) error {
+func InstantiateAgent(agent AgentInfo, hostName, profile string, allowRedeploy bool) error {
 	command := "docker "
 
 	// add -H host name if remote deploying
@@ -31,7 +31,11 @@ func InstantiateAgent(agent AgentInfo, hostName, profile string) error {
 	}
 
 	// append the rest of the command
-	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile %s -p %s up --no-recreate -d", profile, projectName)
+	command += fmt.Sprintf("compose -f /tmp/janus/docker-compose.yml --profile %s -p %s up -d", profile, projectName)
+
+	if !allowRedeploy {
+		command += " --no-recreate"
+	}
 
 	fmt.Println(command)
 	parsedCommand := helper.ParseCommand(command)

--- a/src/janus-cli/cmd/local.go
+++ b/src/janus-cli/cmd/local.go
@@ -63,7 +63,7 @@ func deployAgentLocally() {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, "", "server")
+	err = agent_deploy.InstantiateAgent(agent, "", "server", false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/janus-cli/cmd/remote.go
+++ b/src/janus-cli/cmd/remote.go
@@ -66,7 +66,7 @@ func deployAgentRemotely() {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, hostName, "raspberry")
+	err = agent_deploy.InstantiateAgent(agent, hostName, "raspberry", true)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/janus-controller/local/deploy.go
+++ b/src/janus-controller/local/deploy.go
@@ -12,7 +12,7 @@ import (
 func DeployAgent(ip string) error {
 	// Instantiate Agent
 	agent := agent_deploy.AgentInfo{
-		Name:      "janus-issuer",
+		Name:      "issuer",
 		AdminPort: strconv.Itoa(8002),
 		AgentPort: strconv.Itoa(8001),
 		Endpoint:  fmt.Sprintf("http://%s", ip),

--- a/src/janus-controller/local/deploy.go
+++ b/src/janus-controller/local/deploy.go
@@ -34,7 +34,7 @@ func DeployAgent(ip string) error {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, "", "server")
+	err = agent_deploy.InstantiateAgent(agent, "", "server", false)
 	if err != nil {
 		return err
 	}

--- a/src/janus-controller/remote/provisioning.go
+++ b/src/janus-controller/remote/provisioning.go
@@ -49,7 +49,7 @@ func DeployAgent(provisionBody ProvisionBody) error {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	go agent_deploy.InstantiateAgent(agent, provisionBody.DeviceHostName, "raspberry")
+	go agent_deploy.InstantiateAgent(agent, provisionBody.DeviceHostName, "raspberry", false)
 
 	return nil
 }

--- a/src/janus-controller/remote/provisioning.go
+++ b/src/janus-controller/remote/provisioning.go
@@ -27,7 +27,7 @@ func ProvisionBodyIsValid(body ProvisionBody) bool {
 func DeployAgent(provisionBody ProvisionBody) error {
 	// Instantiate Agent
 	agent := agent_deploy.AgentInfo{
-		Name:      "rasp-holder",
+		Name:      "holder",
 		AdminPort: strconv.Itoa(8002),
 		AgentPort: strconv.Itoa(8001),
 		Endpoint:  fmt.Sprintf("http://%s", strings.Split(provisionBody.DeviceHostName, "@")[1]),

--- a/src/janus-controller/service/service.go
+++ b/src/janus-controller/service/service.go
@@ -28,7 +28,6 @@ type Service struct {
 }
 
 func (s *Service) Init() {
-	//add deploy only if no agent is running
 	err := local.DeployAgent("192.168.0.3")
 	if err != nil {
 		log.Fatal(err)
@@ -70,7 +69,6 @@ func (s *Service) RunApi(port string) {
 		}
 
 		//deploy agent
-		//add deploy only if no agent is running
 		err = remote.DeployAgent(provisionBody)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -122,5 +120,8 @@ func (s *Service) RunApi(port string) {
 	})
 
 	log.Println("Server listening on port ", port)
-	http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	if err != nil {
+		log.Println(err)
+	}
 }

--- a/src/janus-controller/service/service.go
+++ b/src/janus-controller/service/service.go
@@ -28,12 +28,12 @@ type Service struct {
 }
 
 func (s *Service) Init() {
-	err := local.DeployAgent("192.168.0.3")
+	err := local.DeployAgent("192.168.0.10")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	s.ServerClient = acapy.NewClient("http://192.168.0.3:8002")
+	s.ServerClient = acapy.NewClient("http://192.168.0.10:8002")
 
 	helper.TryUntilNoError(s.ServerClient.Status, 600)
 


### PR DESCRIPTION
This PR intents to change our janus-controller and janus-cli deploy comands to avoid unespected redeploys when re-running it.

Also, the names of the containers were changed to avoid long names 