### PR TITLE
PFJ9 deploy multiple agents by config file

### DIFF
--- a/demo/agents.yaml
+++ b/demo/agents.yaml
@@ -3,15 +3,15 @@ default:
   - temperature
   - humidity
   broker:
-    ip: "10.101.42.32"
+    ip: "127.0.0.1"
     username: "admin"
     password: "admin"
 agents:
-  - hostname: pi@10.101.42.34 #rasp
+  - hostname: pi@127.0.0.2 
     sensors:
       - humidity
     broker:
       id: "800a9f"
-  # - hostname: vitor@192.168.0.6 #notebook
-  #   broker:
-  #     id: "e72928"
+  - hostname: pi@127.0.0.3 
+    broker:
+      id: "e72928"

--- a/demo/agents.yaml
+++ b/demo/agents.yaml
@@ -1,0 +1,17 @@
+default:
+  sensors:
+  - temperature
+  - humidity
+  broker:
+    ip: "192.168.0.12"
+    username: "admin"
+    password: "admin"
+agents:
+  - hostname: pi@192.168.0.3 #rasp
+    sensors:
+      - humidity
+    broker:
+      id: "800a9f"
+  - hostname: vitor@192.168.0.6 #notebook
+    broker:
+      id: "e72928"

--- a/demo/agents.yaml
+++ b/demo/agents.yaml
@@ -3,15 +3,15 @@ default:
   - temperature
   - humidity
   broker:
-    ip: "192.168.0.12"
+    ip: "10.101.42.32"
     username: "admin"
     password: "admin"
 agents:
-  - hostname: pi@192.168.0.3 #rasp
+  - hostname: pi@10.101.42.34 #rasp
     sensors:
       - humidity
     broker:
       id: "800a9f"
-  - hostname: vitor@192.168.0.6 #notebook
-    broker:
-      id: "e72928"
+  # - hostname: vitor@192.168.0.6 #notebook
+  #   broker:
+  #     id: "e72928"

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.1
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -12,6 +12,7 @@ import (
 type ComposeInfo struct {
 	Seed      string
 	Name      string
+	HostName  string
 	Endpoint  string
 	AdminPort string
 	AgentPort string
@@ -33,12 +34,12 @@ func parseComposeInfo(info ComposeInfo, cmd *exec.Cmd) {
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CONTROLLER_PORT=%s", info.ControllerPort))
 }
 
-func InstantiateAgent(agent ComposeInfo, hostName, profile string) error {
+func InstantiateAgent(agent ComposeInfo, profile string) error {
 	command := "docker "
 
 	// add -H hostname if remote deploying
-	if hostName != "" {
-		command += fmt.Sprintf("-H ssh://%s ", hostName)
+	if agent.HostName != "" {
+		command += fmt.Sprintf("-H ssh://%s ", agent.HostName)
 	}
 
 	// append the rest of the command

--- a/pkg/controller_handlers/controller.go
+++ b/pkg/controller_handlers/controller.go
@@ -1,0 +1,57 @@
+package controller_handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type ProvisionBody struct {
+	DeviceHostName string   `json:"deviceHostName"` // user@ip
+	Permissions    []string `json:"permissions"`    // ["temperature", "humidity"]
+	BrokerIp       string   `json:"brokerIp"`       // 127.0.0.1
+	BrokerUsername string   `json:"brokerUsername"` // brokerUser:deviceID
+	BrokerPassword string   `json:"brokerPassword"` // brokerPass
+}
+
+func ProvisionBodyIsValid(body ProvisionBody) bool {
+	if body.DeviceHostName == "" || body.BrokerIp == "" || len(body.Permissions) == 0 || body.BrokerUsername == "" || body.BrokerPassword == "" {
+		return false
+	}
+
+	return true
+}
+
+type ControllerService struct {
+	Address string
+}
+
+func (c ControllerService) RequestProvision(body ProvisionBody) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	bodyReader := bytes.NewReader(jsonBody)
+	requestURL := fmt.Sprintf("http://%s/provision", c.Address)
+	req, err := http.NewRequest(http.MethodPost, requestURL, bodyReader)
+	if err != nil {
+		return err
+	}
+
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("provision request failed with status %v", req.Response.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/yaml_parser/yaml_parser.go
+++ b/pkg/yaml_parser/yaml_parser.go
@@ -1,0 +1,113 @@
+package yaml_parser
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Agent struct {
+	Hostname string   `yaml:"hostname"`
+	Sensors  []string `yaml:"sensors"`
+	Broker   struct {
+		IP       string `yaml:"ip"`
+		ID       string `yaml:"id"`
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
+	} `yaml:"broker"`
+}
+
+type Body struct {
+	Default Agent   `yaml:"default"`
+	Agents  []Agent `yaml:"agents"`
+}
+
+func checkAgentRequiredFields(agent Agent) error {
+	emptyFields := []string{}
+	if agent.Hostname == "" {
+		emptyFields = append(emptyFields, "hostname")
+	}
+	if len(agent.Sensors) == 0 {
+		emptyFields = append(emptyFields, "sensors")
+	}
+	if agent.Broker.IP == "" {
+		emptyFields = append(emptyFields, "broker.id")
+	}
+	if agent.Broker.ID == "" {
+		emptyFields = append(emptyFields, "broker.ip")
+	}
+	if agent.Broker.Username == "" {
+		emptyFields = append(emptyFields, "broker.username")
+	}
+	if agent.Broker.Password == "" {
+		emptyFields = append(emptyFields, "broker.password")
+	}
+
+	parsed, err := yaml.Marshal(agent)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
+	if len(emptyFields) > 0 {
+		return fmt.Errorf("missing fields:%s in agent:\n%s", emptyFields, string(parsed))
+	}
+
+	return nil
+}
+
+func validateBody(body Body) error {
+	for _, agent := range body.Agents {
+		err := checkAgentRequiredFields(agent)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func fillAgent(agent, defaultAgent Agent) Agent {
+	if len(agent.Sensors) == 0 {
+		agent.Sensors = defaultAgent.Sensors
+	}
+	if agent.Broker.IP == "" {
+		agent.Broker.IP = defaultAgent.Broker.IP
+	}
+	if agent.Broker.Username == "" {
+		agent.Broker.Username = defaultAgent.Broker.Username
+	}
+	if agent.Broker.Password == "" {
+		agent.Broker.Password = defaultAgent.Broker.Password
+	}
+	return agent
+}
+
+func fillAgents(body *Body) {
+	for i, agent := range body.Agents {
+		body.Agents[i] = fillAgent(agent, body.Default)
+	}
+}
+
+func ParseFile(filepath string) Body {
+	yamlFile, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body := Body{}
+
+	err = yaml.Unmarshal(yamlFile, &body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fillAgents(&body)
+	err = validateBody(body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return body
+}

--- a/src/janus-cli/cmd/holder.go
+++ b/src/janus-cli/cmd/holder.go
@@ -4,15 +4,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/Instituto-Atlantico/janus/pkg/agent_deploy"
 	"github.com/Instituto-Atlantico/janus/pkg/helper"
+	"github.com/Instituto-Atlantico/janus/pkg/yaml_parser"
 	"github.com/spf13/cobra"
 )
 
 var (
 	hostName string
+	file     string
 )
 
 var holderCmd = &cobra.Command{
@@ -20,31 +24,77 @@ var holderCmd = &cobra.Command{
 	Short: "Deploy an aca-py agent remotely",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		if file != "" { //many hosts
+			deployMultipleAgents()
+		} else if hostName != "" { //single host
+			valid := helper.ValidateSSHHostName(hostName)
+			if !valid {
+				log.Fatal("hostname flag must be on user@ip format")
+			}
 
-		valid := helper.ValidateSSHHostName(hostName)
-		if !valid {
-			log.Fatal("hostname flag must be on user@ip format")
+			deploySingleAgent()
+		} else {
+			log.Fatal("Either hostname or filename flags must passed")
 		}
-
-		deployAgentRemotely()
 	},
 }
 
 func init() {
 	deployCmd.AddCommand(holderCmd)
 
+	holderCmd.Flags().StringVarP(&file, "config-file", "F", "", "The yaml file for deploy of multiple hosts at once. Check https://github.com/Instituto-Atlantico/janus/demo/agents.yaml for an example.")
 	holderCmd.Flags().StringVarP(&hostName, "host-name", "H", "", "The hostname of the target host you want to deploy the agent. The required format is user@ip.")
-	holderCmd.MarkFlagRequired("host-name")
 }
 
-func deployAgentRemotely() {
+func deployMultipleAgents() {
+	fmt.Println("call multiple")
+
+	body := yaml_parser.ParseFile(file)
+
+	var wg sync.WaitGroup
+
+	for _, a := range body.Agents {
+
+		wg.Add(1)
+
+		agent := agent_deploy.ComposeInfo{
+			Name:      "holder",
+			HostName:  a.Hostname,
+			AdminPort: "8002",
+			AgentPort: "8001",
+			Endpoint:  fmt.Sprintf("http://%s", strings.Split(a.Hostname, "@")[1]),
+		}
+
+		go func() {
+			log.Printf("deploy agent on %s\n", a.Hostname)
+			defer wg.Done()
+
+			err := deployAgent(agent)
+			if err != nil {
+				log.Println(err)
+				runtime.Goexit() //interrupts the current routine
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func deploySingleAgent() {
 	agent := agent_deploy.ComposeInfo{
 		Name:      "holder",
+		HostName:  hostName,
 		AdminPort: agentApiPort,
 		AgentPort: agentServicePort,
 		Endpoint:  fmt.Sprintf("http://%s", strings.Split(hostName, "@")[1]),
 	}
 
+	err := deployAgent(agent)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func deployAgent(agent agent_deploy.ComposeInfo) error {
 	// generate seed and did
 	seed, did := agent_deploy.ProvideDid()
 	log.Printf("Seed generated: %s\n", seed)
@@ -55,14 +105,16 @@ func deployAgentRemotely() {
 	// log agent
 	parsedAgent, err := json.Marshal(agent)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, hostName, "holder")
+	err = agent_deploy.InstantiateAgent(agent, "holder")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+
+	return nil
 }

--- a/src/janus-cli/cmd/holder.go
+++ b/src/janus-cli/cmd/holder.go
@@ -8,15 +8,19 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Instituto-Atlantico/go-acapy-client"
 	"github.com/Instituto-Atlantico/janus/pkg/agent_deploy"
+	"github.com/Instituto-Atlantico/janus/pkg/controller_handlers"
 	"github.com/Instituto-Atlantico/janus/pkg/helper"
 	"github.com/Instituto-Atlantico/janus/pkg/yaml_parser"
 	"github.com/spf13/cobra"
 )
 
 var (
-	hostName string
-	file     string
+	hostName       string
+	file           string
+	provision      bool
+	controllerAddr string
 )
 
 var holderCmd = &cobra.Command{
@@ -44,6 +48,8 @@ func init() {
 
 	holderCmd.Flags().StringVarP(&file, "config-file", "F", "", "The yaml file for deploy of multiple hosts at once. Check https://github.com/Instituto-Atlantico/janus/demo/agents.yaml for an example.")
 	holderCmd.Flags().StringVarP(&hostName, "host-name", "H", "", "The hostname of the target host you want to deploy the agent. The required format is user@ip.")
+	holderCmd.Flags().BoolVarP(&provision, "provision", "p", false, "Allows auto-provision of the agent on the controller. The flag --controller-address specifies the controller ip  worand is setted as locahost:8081 as default")
+	holderCmd.Flags().StringVarP(&controllerAddr, "controller", "c", "localhost:8081", "The controller address used by auto-provision process for the file deploy")
 }
 
 func deployMultipleAgents() {
@@ -57,7 +63,7 @@ func deployMultipleAgents() {
 
 		wg.Add(1)
 
-		agent := agent_deploy.ComposeInfo{
+		composeInfo := agent_deploy.ComposeInfo{
 			Name:      "holder",
 			HostName:  a.Hostname,
 			AdminPort: "8002",
@@ -65,16 +71,47 @@ func deployMultipleAgents() {
 			Endpoint:  fmt.Sprintf("http://%s", strings.Split(a.Hostname, "@")[1]),
 		}
 
-		go func() {
-			log.Printf("deploy agent on %s\n", a.Hostname)
+		go func(agent yaml_parser.Agent) {
 			defer wg.Done()
 
-			err := deployAgent(agent)
+			log.Printf("deploing agent on %s device\n", agent.Hostname)
+			err := deployAgent(composeInfo)
 			if err != nil {
 				log.Println(err)
 				runtime.Goexit() //interrupts the current routine
 			}
-		}()
+
+			ip := strings.Split(agent.Hostname, "@")[1]
+			client := acapy.NewClient(fmt.Sprintf("http://%s:8002", ip))
+
+			log.Printf("Waiting for agent deploy on %s device\n", agent.Hostname)
+			_, err = helper.TryUntilNoError(func() (acapy.Status, error) {
+				return client.Status()
+			}, 600)
+			if err != nil {
+				log.Printf("error on auto-provisioning for agent %s:%s\n", ip, err)
+			}
+
+			service := controller_handlers.ControllerService{
+				Address: controllerAddr,
+			}
+
+			body := controller_handlers.ProvisionBody{
+				DeviceHostName: agent.Hostname,
+				Permissions:    agent.Sensors,
+				BrokerIp:       agent.Broker.IP,
+				BrokerUsername: fmt.Sprintf("%s:%s", agent.Broker.Username, agent.Broker.ID),
+				BrokerPassword: agent.Broker.Password,
+			}
+			log.Printf("Provisioning agent of %s device on %s controller\n", agent.Hostname, controllerAddr)
+			err = service.RequestProvision(body)
+			if err != nil {
+				log.Println("Error on provisioning: ", err)
+				runtime.Goexit() //interrupts the current routine
+			}
+
+			log.Println("Provisioning done for agent ", agent.Hostname)
+		}(a)
 	}
 	wg.Wait()
 }

--- a/src/janus-cli/cmd/issuer.go
+++ b/src/janus-cli/cmd/issuer.go
@@ -56,7 +56,7 @@ func deployAgentLocally() {
 	log.Printf("Deploying agent: %s\n", parsedAgent)
 
 	// Instantiate Agent
-	err = agent_deploy.InstantiateAgent(agent, "", "issuer")
+	err = agent_deploy.InstantiateAgent(agent, "issuer")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/janus-controller/service/provisioning.go
+++ b/src/janus-controller/service/provisioning.go
@@ -1,1 +1,0 @@
-package service

--- a/src/janus-controller/service/provisioning.go
+++ b/src/janus-controller/service/provisioning.go
@@ -1,17 +1,1 @@
 package service
-
-type ProvisionBody struct {
-	DeviceHostName string   `json:"deviceHostName"` // user@ip
-	Permissions    []string `json:"permissions"`    // ["temperature", "humidity"]
-	BrokerIp       string   `json:"brokerIp"`       // 127.0.0.1
-	BrokerUsername string   `json:"brokerUsername"` // brokerUser:deviceID
-	BrokerPassword string   `json:"brokerPassword"` // brokerPass
-}
-
-func ProvisionBodyIsValid(body ProvisionBody) bool {
-	if body.DeviceHostName == "" || body.BrokerIp == "" || len(body.Permissions) == 0 || body.BrokerUsername == "" || body.BrokerPassword == "" {
-		return false
-	}
-
-	return true
-}

--- a/src/janus-controller/service/service.go
+++ b/src/janus-controller/service/service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Instituto-Atlantico/go-acapy-client"
 	"github.com/Instituto-Atlantico/janus/pkg/agents"
+	"github.com/Instituto-Atlantico/janus/pkg/controller_handlers"
 	"github.com/Instituto-Atlantico/janus/pkg/helper"
 	"github.com/Instituto-Atlantico/janus/pkg/mqtt_pub"
 	"github.com/Instituto-Atlantico/janus/pkg/sensors"
@@ -164,10 +165,10 @@ func (s *Service) RunApi(port string) {
 		}
 
 		// parse body
-		var provisionBody ProvisionBody
+		var provisionBody controller_handlers.ProvisionBody
 		err := json.NewDecoder(r.Body).Decode(&provisionBody)
 
-		if !ProvisionBodyIsValid(provisionBody) || err != nil {
+		if !controller_handlers.ProvisionBodyIsValid(provisionBody) || err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(w, "Invalid body")
 


### PR DESCRIPTION
The objetive of this PR is to add a way to support the deploy of multiple agents at once. For this the command dpeloy command was improved to support this.

The new supported command is janus-cli deploy holder -F ./agents.yaml -p

the supported file format is yaml. An example is available at demo/agents.yaml

```yaml
default:
  sensors:
  - temperature
  - humidity
  broker:
    ip: "10.101.10.10"
    username: "admin"
    password: "admin"
agents:
  - hostname: pi@10.101.10.11 #rasp
    sensors:
      - humidity
    broker:
      id: "800a9f"
  - hostname: user@10.101.10.12 #computer
    broker:
    id: "e72928"
```


