### PR TITLE
Add improvements on janus-controller port

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,10 +8,12 @@ services:
       [
         "/janus-controller",
         "--server-agent-ip",
-        "agent"
+        "agent",
+        "--port",
+        "${CONTROLLER_PORT}"
       ]
     ports:
-      - "${CONTROLLER_PORT}:8081"
+      - "${CONTROLLER_PORT}:${CONTROLLER_PORT}"
     profiles:
       - issuer
 

--- a/docker/dockerfile.controller
+++ b/docker/dockerfile.controller
@@ -22,7 +22,4 @@ FROM alpine:3.9
 # Copy only binary
 COPY --from=build_base /tmp/janus/out/janus-controller /janus-controller
 
-# This container exposes port 8081 to the outside world
-EXPOSE 8081
-
 CMD [ "/janus-controller" ]

--- a/pkg/agent_deploy/agent.go
+++ b/pkg/agent_deploy/agent.go
@@ -31,6 +31,9 @@ func parseComposeInfo(info ComposeInfo, cmd *exec.Cmd) {
 	cmd.Env = append(cmd.Env, fmt.Sprintf("AGENT_PORT=%s", info.AgentPort))
 
 	//Janus-controller
+	if info.ControllerPort == "" {
+		info.ControllerPort = "0"
+	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CONTROLLER_PORT=%s", info.ControllerPort))
 }
 


### PR DESCRIPTION
This PR aims to automate the capture of the janus-controller port, thus getting the Swagger UI url with the correct port if the user uses the --controller-port flag to change the default port, which in this case is 8081.