### PR TITLE
pfj-46 remove device credentials on agent delete endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.20
 
 require github.com/spf13/cobra v1.6.1
 
-require github.com/Instituto-Atlantico/go-acapy-client v0.4.0
+require (
+	github.com/Instituto-Atlantico/go-acapy-client v0.6.0
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
@@ -27,7 +30,6 @@ require (
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
@@ -38,5 +40,4 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggo/http-swagger v1.3.4
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Instituto-Atlantico/go-acapy-client v0.4.0 h1:bD7rshIi0q39Ci8w0bLnLadquJT7Q3tLtX2L2xK/p1Q=
 github.com/Instituto-Atlantico/go-acapy-client v0.4.0/go.mod h1:faJXWBL9AHuvGPfj3N/AV65GZW13iu4YFkHHdn+Ghos=
+github.com/Instituto-Atlantico/go-acapy-client v0.6.0 h1:CVRYx8DqgCZuHCRpZP6ZjbvVGctcxqaZnmnCb079Efc=
+github.com/Instituto-Atlantico/go-acapy-client v0.6.0/go.mod h1:faJXWBL9AHuvGPfj3N/AV65GZW13iu4YFkHHdn+Ghos=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=

--- a/pkg/agents/agents.go
+++ b/pkg/agents/agents.go
@@ -86,6 +86,12 @@ func GetCredential(holder *acapy.Client, attr, value string) (acapy.Credential, 
 	return credentials[0], nil
 }
 
+func DeleteCredential(holder *acapy.Client, referent string) error {
+	err := holder.RemoveCredential(referent)
+
+	return err
+}
+
 // issuer sends a presentation
 func CreateRequestPresentationForSensor(issuer *acapy.Client, credentialDefinition, connectionId, sensorName string) (acapy.PresentationExchangeRecord, error) {
 	requestedPredicates := map[string]acapy.RequestedPredicate{}

--- a/src/janus-controller/service/service.go
+++ b/src/janus-controller/service/service.go
@@ -314,7 +314,7 @@ func deleteAgent(s *Service) {
 		}
 
 		delete(s.Agents, ip)
-		log.InfoLogger("Device with ip %s was removed", ip)
+		log.InfoLogger(" The Device with ip %s was removed", ip)
 	})
 }
 


### PR DESCRIPTION
The objetive of this PR is to remove the device credential to allow the re-deploy chaging the device's permissions